### PR TITLE
fix: avoid cloning accessor properties

### DIFF
--- a/ark/util/clone.ts
+++ b/ark/util/clone.ts
@@ -31,8 +31,12 @@ const _clone = (input: unknown, seen: Map<unknown, unknown> | null): any => {
 
 	if (seen) {
 		seen.set(input, cloned)
-		for (const k in propertyDescriptors)
-			propertyDescriptors[k].value = _clone(propertyDescriptors[k].value, seen)
+		for (const k in propertyDescriptors) {
+			const desc = propertyDescriptors[k]
+
+			if ("get" in desc || "set" in desc) continue
+			desc.value = _clone(desc.value, seen)
+		}
 	}
 
 	Object.defineProperties(cloned, propertyDescriptors)


### PR DESCRIPTION
Ignore accessor properties to prevent assigning a “value” field when a getter or setter exists

This is my first pr, so please tell me if i missed someting.

This pr prevents the error "TypeError: Invalid property.  'value' present on property with getter or setter." when trying to parse an object with a getter or setter.

As an example, you would need to pass `process.env` with an spread operator(`{ process.env }`) so it could be validated and not throw an error by the lib. With this fix, now it can be validated correctly without the spread operator.

I think the test "can clone process.env" at [clone.test.ts](../blob/main/ark/type/__tests__/clone.test.ts) might need to be changed to reflect this new behavior.